### PR TITLE
Fix tasks path resolution

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -1,7 +1,9 @@
 import sys
 import os
 
-TASKS_FILE = 'tasks.txt'
+# Always resolve tasks.txt relative to this script so the GUI works no matter
+# where it is launched from.
+TASKS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tasks.txt')
 
 def load_tasks():
     if not os.path.exists(TASKS_FILE):
@@ -55,4 +57,4 @@ def main():
         print('Invalid command or arguments.')
 
 if __name__ == '__main__':
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- store `tasks.txt` next to todo.py so the GUI can save tasks regardless of cwd

## Testing
- `python -m py_compile todo.py gui.py`
- `python todo.py list`
- `python todo.py add "Test"`
- `python todo.py list`


------
https://chatgpt.com/codex/tasks/task_e_684c772d8a10833185458f25e94b6062